### PR TITLE
Fix minor typo in rewrite.py comment

### DIFF
--- a/tree_plus_programs/rewrite.py
+++ b/tree_plus_programs/rewrite.py
@@ -14,7 +14,7 @@
 # rewrite the tree_plus engine.py module in Rust:
 # rw -C ../tree_plus_src/engine.py ./engine.rs
 
-# for specific lenths use -l
+# for specific lengths use -l
 # rw -l 420 [input-path] [output-path]
 
 from pathlib import Path


### PR DESCRIPTION
## Summary
- correct 'lenths' typo to 'lengths' in rewrite usage comment

## Testing
- `pytest -q` *(fails: test_stub_tests.py assertions)*

------
https://chatgpt.com/codex/tasks/task_e_6840a020037c832ab7e844accc72b689