### PR TITLE
Fix duplicate comment removal in parse_metal

### DIFF
--- a/tree_plus_src/parse_file.py
+++ b/tree_plus_src/parse_file.py
@@ -289,8 +289,6 @@ def parse_metal(content: str, *, timeout: float = DEFAULT_REGEX_TIMEOUT) -> List
     # Remove comments first
     content = remove_c_comments(content, timeout=timeout)
 
-    content = remove_c_comments(content, timeout=timeout)
-
     # Attributes: [[...]]
     # Correctly handles nested brackets within attributes if any, and non-greedy matching.
     attribute_regex_str = r"(?:\[\[(?:[^\[\]]|\[[^\[\]]*\])*\]\]\s*)*"


### PR DESCRIPTION
## Summary
- remove redundant `remove_c_comments` call in `parse_metal`

## Testing
- `pytest tests/test_more_language_units.py::test_more_languages_group_7 -q`


------
https://chatgpt.com/codex/tasks/task_e_68409e074f6c832a82ffd2257c87239c