### PR TITLE
Fix wiki action link

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4,3 +4,8 @@ from tree_plus_src import web
 def test_articles_from_hacker_news():
     articles = web.articles_from_hacker_news(max_depth=1, n_articles=1)
     assert bool(articles)
+
+
+def test_create_link_wiki():
+    link = web.create_link("wiki", "Stack Overflow")
+    assert "https://en.wikipedia.org/wiki/stack_overflow" in link

--- a/tree_plus_src/web.py
+++ b/tree_plus_src/web.py
@@ -44,7 +44,7 @@ def create_link(kind: Action, query: str) -> str:
     if kind == "search_wikipedia":
         link = create_wikipedia_search_link(query)
     elif kind == "wiki":
-        link = create_google_search_link(query)
+        link = create_wikipedia_link(query)
     elif kind == "search_google":
         link = create_stack_overflow_search_link(query)
     assert link is not None
@@ -87,6 +87,19 @@ def create_wikipedia_search_link(
     wikipedia_search_link += f"{prefix}{subterm}{suffix}"
     wikipedia_search_link += f"[/link][/{link_style}]"
     return wikipedia_search_link
+
+
+def create_wikipedia_link(
+    subterm: str,
+    prefix: str = "",
+    suffix: str = "",
+    link_style: str = LINK_STYLE,
+) -> str:
+    wikipedia_url = create_wikipedia_url(subterm)
+    wikipedia_link = f"[{link_style}][link={wikipedia_url}]"
+    wikipedia_link += f"{prefix}{subterm}{suffix}"
+    wikipedia_link += f"[/link][/{link_style}]"
+    return wikipedia_link
 
 
 def create_google_search_link(


### PR DESCRIPTION
## Summary
- add `create_wikipedia_link` helper
- use it for the `wiki` action in `create_link`
- test `create_link` for wiki

## Testing
- `pytest tests/test_web.py::test_create_link_wiki -q`
- `pytest -q` *(fails: test_cli_on_folder_with_evil_logging, test_dotenv, test_programs_hello_tree_plus, test_programs_stub_tests, test_remove_decorators, test_make_import_path, test_stub_tests, test_main, test_class_vehicle, test_class_car)*

------
https://chatgpt.com/codex/tasks/task_e_6840a020a3b0832a9044e5247f069f1e