### PR TITLE
Fix syntax flag docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Usage: tree_plus_cli.py [OPTIONS] [PATHS]...
           Override DEFAULT_IGNORE: Only ignore .ini files.
               > tree_plus -o -i "*.ini" tests/dot_dot
 
-          Syntax Highlight python files in src and tests
-              > tree_plus -s tree_plus_src/*.py tests/*.py
+         Disable syntax highlighting for python files in src and tests
+             > tree_plus -s tree_plus_src/*.py tests/*.py
 
           Concise Mode (No Parsing)
               > tree_plus -c

--- a/tree_plus_cli.py
+++ b/tree_plus_cli.py
@@ -211,7 +211,7 @@ def main(
             > tree_plus -o -i "*.ini" tests/dot_dot
 
         \b
-        Syntax Highlight python files in src and tests
+        Disable syntax highlighting for python files in src and tests
             > tree_plus -s tree_plus_src/*.py tests/*.py
 
         \b


### PR DESCRIPTION
## Summary
- document that `-s` disables highlighting in README
- sync CLI help text with README

## Testing
- `make test-sequential`
- `make test-tp-dotdot`
- `make test-e2e`
- `make test-cli`
- `make test-programs`
- `make test-deploy`


------
https://chatgpt.com/codex/tasks/task_e_6840a021775c832a9dd597a9892ad7ef